### PR TITLE
`:encoding :utf-8` in `defsystem` forms

### DIFF
--- a/pzmq.asd
+++ b/pzmq.asd
@@ -2,6 +2,7 @@
 
 (asdf:defsystem pzmq
   :description "ZeroMQ 3.2+ bindings."
+  :encoding :utf-8
   :author "Orivej Desh <orivej@gmx.fr>"
   :licence "MIT"
   :depends-on (cffi)
@@ -14,14 +15,17 @@
 
 (asdf:defsystem pzmq-compat
   :depends-on (pzmq)
+  :encoding :utf-8
   :components ((:file "compat")))
 
 (asdf:defsystem pzmq-test
   :depends-on (pzmq fiveam let-plus bordeaux-threads)
+  :encoding :utf-8
   :components ((:file "tests")))
 
 (asdf:defsystem pzmq-examples
   :depends-on (pzmq split-sequence iterate local-time bordeaux-threads)
+  :encoding :utf-8
   :components ((:file "examples")))
 
 (defmethod asdf:perform ((op asdf:test-op) (system (eql (find-system :pzmq))))


### PR DESCRIPTION
Hi,

This patch adds `:encoding :utf-8` to all `defsystem` forms.  This enables ASDF/Quicklisp to load the system even if the user's Lisp implementation's default external format is not set to UTF-8.

Without this patch, I, for one, am unable to load the system due to `read` decoding errors.
