### PR TITLE
Improvements to the proxy functionality

### DIFF
--- a/c-api.lisp
+++ b/c-api.lisp
@@ -575,3 +575,9 @@ Connected socket may not receive messages sent before it was bound.
   (device device)
   (frontend :pointer)
   (backend :pointer))
+
+(defcfun* proxy (:int t)
+  "Start a proxy"
+  (frontend :pointer)
+  (backend :pointer)
+  (capture :pointer))

--- a/package.lisp
+++ b/package.lisp
@@ -102,4 +102,5 @@ Consult @a[http://api.zeromq.org/4-0:zmq]{official C API reference} first.
    #:with-socket
    #:with-sockets
    #:with-poll-items
-   #:revents))
+   #:revents
+   #:proxy))


### PR DESCRIPTION
This patch contains two improvements: It implements the PROXY function, and it also enabled the restart functionality for the DEVICE function. The latter is needed on OSX since you can get sporadic interruptions where you need to invoke the "continue" restart.
