### PR TITLE
Size of msg_t increased in ZMQ 4.1.x

### DIFF
--- a/c-api.lisp
+++ b/c-api.lisp
@@ -194,7 +194,7 @@ Get context options."
 
 (defcstruct %msg
   "Concealed structure, defined only to know its size."
-  (_ :unsigned-char :count 32))
+  (_ :unsigned-char :count 64))
 
 (defcfun* msg-init (:int)
   "Initialise empty ØMQ message.


### PR DESCRIPTION
 - The size of the opaque message buffer, zmq_msg_t, changed from 32
   bytes to 64 bytes in ZMQ version 4.1.x