### PR TITLE
Fix msg-more

### DIFF
--- a/c-api.lisp
+++ b/c-api.lisp
@@ -267,7 +267,7 @@ Low-level API. Consider using @fun{WITH-MESSAGE}."
 
 (defun msg-more (msg)
   "Indicate if there are more message parts to receive."
-  (if (zerop (%msg-more msg)) t nil))
+  (not (zerop (%msg-more msg))))
 
 (defcfun ("zmq_msg_get" %msg-get) :int
   "Get message property."

--- a/c-api.lisp
+++ b/c-api.lisp
@@ -267,7 +267,7 @@ Low-level API. Consider using @fun{WITH-MESSAGE}."
 
 (defun msg-more (msg)
   "Indicate if there are more message parts to receive."
-  (not (zerop (%msg-more msg))))
+  (plusp (%msg-more msg)))
 
 (defcfun ("zmq_msg_get" %msg-get) :int
   "Get message property."


### PR DESCRIPTION
`msg-more` was mapping 0 to `t` and non-zero to `nil`. It should be 0 to `nil` and non-zero to `t`.