### PR TITLE
Fix grovel for MacPorts

### DIFF
--- a/c-api.lisp
+++ b/c-api.lisp
@@ -1,7 +1,8 @@
 (in-package #:pzmq)
 
 (define-foreign-library libzmq
-  (unix (:or "libzmq.so.3.0.0" "libzmq.so.3" "libzmq"))
+  (:darwin "libzmq.dylib")
+  (:unix (:or "libzmq.so.3.0.0" "libzmq.so.3" "libzmq"))
   (t (:default "libzmq")))
 
 (use-foreign-library libzmq)

--- a/grovel.lisp
+++ b/grovel.lisp
@@ -1,4 +1,8 @@
 (in-package #:pzmq)
+#+darwin
+(cc-flags "-I/opt/local/include")
+#+(or freebsd openbsd)
+(cc-flags "-I/usr/local/include")
 (include "zmq.h")
 (ctype size "size_t")
 (cstruct %msg "zmq_msg_t")


### PR DESCRIPTION
Grovel apparently doesn't know about `/opt/local/include` for MacPorts. Even in CFFI's own [libffi](https://github.com/cffi/cffi/blob/c55479168b7e5546da8e67c4d8d7d043992a1353/libffi/libffi-types.lisp) `cc-flags` are explicitly specified. See yitzchak/common-lisp-jupyter#32

I also added an explicit darwin case for `define-foreign-library` to prevent MacOS from falling into the unix case.