### PR TITLE
Use uint64 on win64 for fd type

### DIFF
--- a/c-api.lisp
+++ b/c-api.lisp
@@ -583,9 +583,13 @@ Connected socket may not receive messages sent before it was bound.
   (len size)
   (flags :int))
 
+;; NOTE: In recent versions of libzmq the type zmq_fd_t is intruduced to account
+;; for the varying size of the fd slot. Unfortunately earlier versions used an
+;; #ifdef to substitute int with SOCKET on Windows so we cannot grovel this type
+;; easily.
 (defcstruct pollitem
   (socket :pointer)
-  (fd :int)
+  (fd #+(and windows 64-bit) :uint64 #-(and windows 64-bit) :int)
   (events events)
   (revents events))
 

--- a/pzmq.asd
+++ b/pzmq.asd
@@ -4,7 +4,7 @@
   :description "ZeroMQ 3.2+ bindings."
   :author "Orivej Desh <orivej@gmx.fr>"
   :licence "Unlicense" ; http://unlicense.org/UNLICENSE
-  :depends-on (cffi)
+  :depends-on (cffi trivial-features)
   :serial t
   :encoding :utf-8
   :components ((:file "package")


### PR DESCRIPTION
`zmq_poll` appears broken on win64 due to the fact that the fd slot in the poll struct is a uint64 on that OS. The most recent version of libzmq uses the type `zmq_fd_t` to account for this. Unfortunately. there are versions of libzmq around on Windows and elsewhere that don't have this type. Older versions just had a `#ifdef` directly in the struct definition subsituting the `SOCKET` type on Windows. To account for this I used a read-time conditional instead. 

The original issue is from common-lisp-jupyter, The details are at the **very bottom** of the issue.

https://github.com/yitzchak/common-lisp-jupyter/issues/65#issuecomment-835953322