### PR TITLE
Grovel zmq_pollitem_t

### DIFF
--- a/c-api.lisp
+++ b/c-api.lisp
@@ -411,11 +411,6 @@ Low-level API. Consider using @fun{WITH-MESSAGE}."
   (:gssapi-service-principal-nametype 91)
   (:bindtodevice 92))
 
-(defbitfield (events :short)
-  :pollin
-  :pollout
-  :pollerr)
-
 (defcfun ("zmq_getsockopt" %getsockopt) :int
   "Get ØMQ socket options."
   (socket :pointer)
@@ -582,12 +577,6 @@ Connected socket may not receive messages sent before it was bound.
   (buf :string)
   (len size)
   (flags :int))
-
-(defcstruct pollitem
-  (socket :pointer)
-  (fd :int)
-  (events events)
-  (revents events))
 
 (defcfun ("zmq_poll" %poll) :int
   (items :pointer)

--- a/grovel.lisp
+++ b/grovel.lisp
@@ -2,6 +2,14 @@
 (include "zmq.h")
 (ctype size "size_t")
 (cstruct %msg "zmq_msg_t")
+(bitfield (events :base-type :short)
+  ((:pollin "ZMQ_POLLIN"))
+  ((:pollout "ZMQ_POLLOUT"))
+  ((:pollerr "ZMQ_POLLERR")))
+(cstruct pollitem "zmq_pollitem_t"
+  (socket "socket" :type :pointer)
+  (events "events" :type events)
+  (revents "revents" :type events))
 (constantenum
  c-errors
 ;;; awk -F '[*:]' '/\*E.+\*::/ {print $2}' doc/* | sort | uniq | awk '{print " ((:" tolower($1),  "\"" $1 "\"))"}' | xclip


### PR DESCRIPTION
This accounts for variable fd size on Windows.

Fixes #34